### PR TITLE
fix: save new settigs to backend

### DIFF
--- a/src/js/pages/handlerSettingsPage.js
+++ b/src/js/pages/handlerSettingsPage.js
@@ -2,6 +2,7 @@ import {
   actionAuth,
   setStorageFromObject,
   saveAuth,
+  defaultSettings,
 } from '../utils';
 import { goToAuthPage, getAvatar } from '../header';
 import { pushUserSettings, getUserSettings } from '../api';
@@ -14,7 +15,7 @@ import {
 export const handlerSettingsPage = async () => {
   const currentSettings = await getUserSettings();
   renderSettings(currentSettings);
-  const newSettings = Object.assign(currentSettings);
+  const newSettings = Object.assign(defaultSettings);
   getAvatar();
   document
     .querySelector('.settings-form')

--- a/src/js/utils/defaultSettings.js
+++ b/src/js/utils/defaultSettings.js
@@ -1,0 +1,21 @@
+const icon = { iconURL: 'none' };
+export const defaultSettings = {
+  wordsPerDay: 50,
+  optional: {
+    icon: icon.iconURL,
+    newWordsPerDay: 10,
+    maxCardsPerDay: 10,
+    soundAutoPlay: true,
+    showDeleteBtn: true,
+    showStrongBtn: true,
+    showAnswerBtn: true,
+    onlyNewWords: true,
+    cardInfo: {
+      translation: true,
+      meaning: true,
+      example: true,
+      transcription: true,
+      associationImg: true,
+    },
+  },
+};

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -10,3 +10,4 @@ export { setStorageFromObject } from './setStorageFromObject';
 export { getDate } from './getDate';
 export { getDayOfYear } from './getDayOfYear';
 export { addError } from './addError';
+export { defaultSettings } from './defaultSettings';


### PR DESCRIPTION
Раньше при добавлении новых настроек они не учитывались, тк мы забирали с бэка объект настроек, пробегались по его ключам и выставляли новые значения, после чего отправляли обратно на бэк. Теперь мы пробегаемся по ключам объекта в defaultSettings и отправляем уже его.